### PR TITLE
add new test for regr learner and add order column into feature set

### DIFF
--- a/R/TaskFcst.R
+++ b/R/TaskFcst.R
@@ -60,7 +60,7 @@ TaskFcst = R6Class(
 
       assert_subset(order, col_roles$feature, empty.ok = FALSE)
       self$col_roles$order = order
-      self$col_roles$feature = setdiff(col_roles$feature, order)
+      self$col_roles$feature = union(col_roles$feature, order)
       if (length(key) > 0L) {
         assert_subset(key, col_roles$feature)
         self$col_roles$key = key

--- a/tests/testthat/test_regr_learner.R
+++ b/tests/testthat/test_regr_learner.R
@@ -1,0 +1,14 @@
+skip_if_not_installed(c("mlr3learners", "ranger"))
+
+test_that("autotest", {
+  fcst_tsk = tsk("airpassengers")
+  learner = lrn("regr.ranger")
+
+  learner$train(fcst_tsk)
+  expect_no_error(learner$predict(fcst_tsk))
+
+  if (FALSE) {
+    result = run_autotest(learner)
+    expect_true(result, info = result$error)
+  }
+})

--- a/tests/testthat/test_regr_learner.R
+++ b/tests/testthat/test_regr_learner.R
@@ -1,7 +1,14 @@
-skip_if_not_installed(c("mlr3learners", "ranger"))
+skip_if_not_installed(c("mlr3learners", "ranger", "dplyr"))
 
 test_that("autotest", {
-  fcst_tsk = tsk("airpassengers")
+  fcst_dat = tsk("airpassengers")$data() |>
+    dplyr::mutate(month = as.numeric(month))
+  fcst_tsk = as_task_fcst(
+    fcst_dat,
+    target = "passengers",
+    order = "month",
+    freq = "monthly"
+  )
   learner = lrn("regr.ranger")
 
   learner$train(fcst_tsk)


### PR DESCRIPTION
This PR does 2 things as the title suggested:

1. Added a new test for a regr learner (specifically `regr.ranger`), which will fail and fixed by point 2
2. Added the order column into the task feature sets