### PR TITLE
Support Paradox 2 diagnostics in forecasting snapshots

### DIFF
--- a/tests/testthat/_snaps/paradox-2/PipeOpFcstLags.md
+++ b/tests/testthat/_snaps/paradox-2/PipeOpFcstLags.md
@@ -1,0 +1,15 @@
+# PipeOpFcstLags rejects non-positive lags
+
+    Code
+      po("fcst.lags", lags = 0L)
+    Condition
+      Error in `.__paradox2_ParamSet__values()`:
+      ! Assertion on 'xs' failed: lags: Element 1 is not >= 1.
+
+---
+
+    Code
+      po("fcst.lags", lags = c(1L, -1L))
+    Condition
+      Error in `.__paradox2_ParamSet__values()`:
+      ! Assertion on 'xs' failed: lags: Element 2 is not >= 1.

--- a/tests/testthat/_snaps/paradox-2/PipeOpFcstRolling.md
+++ b/tests/testthat/_snaps/paradox-2/PipeOpFcstRolling.md
@@ -1,0 +1,7 @@
+# PipeOpFcstRolling rejects non-integer finite window sizes
+
+    Code
+      po("fcst.rolling", window_sizes = 2.5)
+    Condition
+      Error in `.__paradox2_ParamSet__values()`:
+      ! Assertion on 'xs' failed: window_sizes: Finite window sizes must be whole numbers. Use `Inf` for an expanding window.

--- a/tests/testthat/test_PipeOpFcstLags.R
+++ b/tests/testthat/test_PipeOpFcstLags.R
@@ -3,8 +3,9 @@ test_that("PipeOpFcstLags declares fcst_iterative property", {
 })
 
 test_that("PipeOpFcstLags rejects non-positive lags", {
-  expect_snapshot(po("fcst.lags", lags = 0L), error = TRUE)
-  expect_snapshot(po("fcst.lags", lags = c(1L, -1L)), error = TRUE)
+  snapshot_variant = if (packageVersion("paradox") >= "2.0.0") "paradox-2" else NULL
+  expect_snapshot(po("fcst.lags", lags = 0L), error = TRUE, variant = snapshot_variant)
+  expect_snapshot(po("fcst.lags", lags = c(1L, -1L)), error = TRUE, variant = snapshot_variant)
 })
 
 test_that("PipeOpFcstLags aligns train features on date-major keyed task", {

--- a/tests/testthat/test_PipeOpFcstRolling.R
+++ b/tests/testthat/test_PipeOpFcstRolling.R
@@ -72,5 +72,6 @@ test_that("PipeOpFcstRolling mixes finite and expanding windows", {
 })
 
 test_that("PipeOpFcstRolling rejects non-integer finite window sizes", {
-  expect_snapshot(po("fcst.rolling", window_sizes = 2.5), error = TRUE)
+  snapshot_variant = if (packageVersion("paradox") >= "2.0.0") "paradox-2" else NULL
+  expect_snapshot(po("fcst.rolling", window_sizes = 2.5), error = TRUE, variant = snapshot_variant)
 })


### PR DESCRIPTION
> Keep the existing Paradox 1 forecasting snapshots byte-for-byte unchanged
> and select Paradox-2 variants for the three affected validation-call
> headers. The diagnostic bodies and production behavior are unchanged;
> Paradox 2 only reports its native
> `.__paradox2_ParamSet__values()` gateway where Paradox 1 reports
> `self$assert()`.

